### PR TITLE
解决了【任务管理】&【Datax任务模板】-【添加】Cron栏选完定时时间后，键盘点击删除键按钮，出现undefined字符的BUG

### DIFF
--- a/src/views/datax/jobInfo/index.vue
+++ b/src/views/datax/jobInfo/index.vue
@@ -151,7 +151,13 @@
               </span>
             </el-dialog>
             <el-form-item label="Cron" prop="jobCron">
-              <el-input v-model="temp.jobCron" auto-complete="off" placeholder="请输入Cron表达式">
+              <!--
+             解决了删除jobCron输入框时会出现undefined的问题
+             因为不需要要通过输入框修改Cron，所以把该输入框设置为readonly
+             修改在CronBox中进行
+             BY 张增燊
+              -->
+              <el-input v-model="temp.jobCron" auto-complete="off" v-on:click.native="showCronBox = true" readonly placeholder="请输入Cron表达式">
                 <el-button v-if="!showCronBox" slot="append" icon="el-icon-turn-off" title="打开图形配置" @click="showCronBox = true" />
                 <el-button v-else slot="append" icon="el-icon-open" title="关闭图形配置" @click="showCronBox = false" />
               </el-input>

--- a/src/views/datax/jobTemplate/index.vue
+++ b/src/views/datax/jobTemplate/index.vue
@@ -125,7 +125,12 @@
               </span>
             </el-dialog>
             <el-form-item label="Cron" prop="jobCron">
-              <el-input v-model="temp.jobCron" auto-complete="off" placeholder="请输入Cron表达式">
+              <!--
+              解决了删除jobCron输入框时会出现undefined的问题
+              因为不需要要通过输入框修改Cron，所以把该输入框设置为readonly
+              修改在CronBox中进行
+               -->
+              <el-input v-model="temp.jobCron" auto-complete="off" v-on:click.native="showCronBox = true" readonly placeholder="请输入Cron表达式">
                 <el-button v-if="!showCronBox" slot="append" icon="el-icon-turn-off" title="打开图形配置" @click="showCronBox = true" />
                 <el-button v-else slot="append" icon="el-icon-open" title="关闭图形配置" @click="showCronBox = false" />
               </el-input>

--- a/src/views/datax/jobTemplate/index.vue
+++ b/src/views/datax/jobTemplate/index.vue
@@ -129,6 +129,7 @@
               解决了删除jobCron输入框时会出现undefined的问题
               因为不需要要通过输入框修改Cron，所以把该输入框设置为readonly
               修改在CronBox中进行
+              BY 张增燊
                -->
               <el-input v-model="temp.jobCron" auto-complete="off" v-on:click.native="showCronBox = true" readonly placeholder="请输入Cron表达式">
                 <el-button v-if="!showCronBox" slot="append" icon="el-icon-turn-off" title="打开图形配置" @click="showCronBox = true" />


### PR DESCRIPTION
解决了【任务管理】&【Datax任务模板】-【添加】Cron栏选完定时时间后，键盘点击删除键按钮，出现undefined字符的BUG，
因为不需要要通过输入框修改Cron，所以把该输入框设置为readonly，修改在CronBox中进行